### PR TITLE
token cache is disabled by default & beauty auth message

### DIFF
--- a/msauth/app.go
+++ b/msauth/app.go
@@ -43,7 +43,7 @@ func (app *App) ImportCache(path string) error {
 func (app *App) ExportCache(path string) error {
 	app.tokenCache.mutex.Lock()
 	defer app.tokenCache.mutex.Unlock()
-	b, err := json.Marshal(app.tokenCache.cache)
+	b, err := json.MarshalIndent(app.tokenCache.cache, "", "  ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. Token cache is disabled by default, for the security consideration.
   If user wants to opt-in, one needs to set the env var
   `OUTLOOK_TOKEN_CACHE_PATH` explicitly.
2. Beautify the device flow auth message path.