### PR TITLE
outlook_message_rule: handle sequence

### DIFF
--- a/outlook/services/message_rule_resource_test.go
+++ b/outlook/services/message_rule_resource_test.go
@@ -58,6 +58,44 @@ func TestAccMessageRuleResource_upgrade(t *testing.T) {
 	})
 }
 
+func TestAccMessageRuleResource_multipleRuleSequence(t *testing.T) {
+	suffix := acctest.RandString(3)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { preCheck(t) },
+		ProviderFactories: providerFactories,
+		// TODO: CheckDestroy: ,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMessageRuleConfig_multipleRuleSeq1(suffix),
+				// Check:  resource.ComposeTestCheckFunc(
+				// // testCheckMailFolderExists(t, "name"),
+				// ),
+			},
+			importStep("outlook_message_rule.test1"),
+			importStep("outlook_message_rule.test2"),
+			importStep("outlook_message_rule.test3"),
+			{
+				Config: testAccMessageRuleConfig_multipleRuleSeq2(suffix),
+				// Check:  resource.ComposeTestCheckFunc(
+				// // testCheckMailFolderExists(t, "name"),
+				// ),
+			},
+			importStep("outlook_message_rule.test1"),
+			importStep("outlook_message_rule.test2"),
+			importStep("outlook_message_rule.test3"),
+			{
+				Config: testAccMessageRuleConfig_multipleRuleSeq1(suffix),
+				// Check:  resource.ComposeTestCheckFunc(
+				// // testCheckMailFolderExists(t, "name"),
+				// ),
+			},
+			importStep("outlook_message_rule.test1"),
+			importStep("outlook_message_rule.test2"),
+			importStep("outlook_message_rule.test3"),
+		},
+	})
+}
+
 func testAccMessageRuleConfig_basic(suffix string) string {
 	return fmt.Sprintf(`
 resource "outlook_message_rule" "test" {
@@ -92,6 +130,68 @@ resource "outlook_message_rule" "test" {
     mark_as_read   = true
     copy_to_folder = outlook_mail_folder.test.id
   }
+}
+`, suffix)
+}
+
+func testAccMessageRuleConfig_multipleRuleSeq1(suffix string) string {
+	return fmt.Sprintf(`
+resource "outlook_message_rule" "test1" {
+  name     = "msgrule-%[1]s1"
+  sequence = "1"
+  enabled  = false
+  action {
+    mark_as_read = true
+  }
+}
+resource "outlook_message_rule" "test2" {
+  name     = "msgrule-%[1]s2"
+  sequence = "2"
+  enabled  = false
+  action {
+    mark_as_read = true
+  }
+  depends_on = [outlook_message_rule.test1]
+}
+resource "outlook_message_rule" "test3" {
+  name     = "msgrule-%[1]s3"
+  sequence = "3"
+  enabled  = false
+  action {
+    mark_as_read = true
+  }
+  depends_on = [outlook_message_rule.test2]
+}
+`, suffix)
+}
+
+func testAccMessageRuleConfig_multipleRuleSeq2(suffix string) string {
+	return fmt.Sprintf(`
+resource "outlook_message_rule" "test1" {
+  name     = "msgrule-%[1]s1"
+  sequence = "3"
+  enabled  = false
+  action {
+    mark_as_read = true
+  }
+  depends_on = [outlook_message_rule.test3]
+}
+resource "outlook_message_rule" "test2" {
+  name     = "msgrule-%[1]s2"
+  sequence = "1"
+  enabled  = false
+  action {
+    mark_as_read = true
+  }
+}
+resource "outlook_message_rule" "test3" {
+  name     = "msgrule-%[1]s3"
+  sequence = "2"
+  enabled  = false
+  action {
+    mark_as_read = true
+  }
+  depends_on = [outlook_message_rule.test2]
 }
 `, suffix)
 }

--- a/outlook/utils/utils.go
+++ b/outlook/utils/utils.go
@@ -14,6 +14,13 @@ func ResponseErrorWasNotFound(err error) bool {
 	return false
 }
 
+func MessageResponseErrorWasNotFound(err error) bool {
+	if errRes, ok := err.(*msgraph.ErrorResponse); ok {
+		return errRes.StatusCode() == http.StatusNotFound || errRes.StatusCode() == http.StatusInternalServerError
+	}
+	return false
+}
+
 func ImportAsExistsError(resourceName, id string) diag.Diagnostics {
 	msg := "A resource with the ID %q already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for %q for more information."
 	return diag.Errorf(msg, id, resourceName)

--- a/website/docs/r/message_rule.html.markdown
+++ b/website/docs/r/message_rule.html.markdown
@@ -38,13 +38,15 @@ The following arguments are supported:
 
 * `action` - (Required) A `action` block as defined below.
 
-* `sequence` - (Required) Indicates the order in which the rule is executed, among other rules.
-
 ---
 
 * `condition` - (Optional) A `condition` block as defined below. The messages meet the condition will be processed.
 
 * `enabled` - (Optional) Should the Message Rule be enabled?
+
+* `sequence` - (Optional) Indicates the order in which the rule is executed, among other rules (the lower number executes first). User should specify a unique and sequential number to each rule. Defaults to 65535.
+
+~> **NOTE**: Even if `sequence` is specified, it has no effect on creation. Outlook API will reset the sequence number based on the creation order in FIFO. User can either rerun `terraform apply` until `terraform plan` doesn't give any differences, or explicitly control the creation order via [`depends_on`](https://www.terraform.io/docs/configuration/resources.html#depends_on-explicit-resource-dependencies).
 
 * `exception` - (Optional) Same as `condition`, except the messages meet the condition will not be processed.
 


### PR DESCRIPTION
Sequence is ignored but required during creation. During creation,
service only honor the creation order and assign the actual sequence
based on that. In order to make the specified sequence match the final
one, one option is to addtionally specify `depends_on`, as is done in
acctest.

Besides, the API will return 500 if message rule is absent (rather than
404).